### PR TITLE
Fix init prompt in NoteHost CLI

### DIFF
--- a/src/cli/init-repo.ts
+++ b/src/cli/init-repo.ts
@@ -19,7 +19,12 @@ export async function initRepo(domain) {
       : templates[0]
 
   console.log(`\n🎬 Ready to generate NoteHost worker in: ${sdkDir}`)
-  await confirm({ message: 'Continue?', default: true })
+  const confirmed = await confirm({ message: 'Continue?', default: true })
+
+  if (!confirmed) {
+    console.log('Aborted.')
+    process.exit(0)
+  }
 
   console.log('Generating...')
 


### PR DESCRIPTION
## Summary
- honor the user's confirmation when running `notehost init`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f86df978083228b8a3d64989e86c0