### PR TITLE
Add vitest and tests for domain validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "build": "npm run prebuild && tsup src/index.ts --format cjs,esm --dts-resolve --clean --sourcemap --out-dir dist && npm run build:cli",
     "build:cli": "tsup src/cli/index.ts --format esm --clean --out-dir dist/cli",
     "release": "npm run build && changeset publish",
-    "lint": "echo Fix lint!"
+    "lint": "echo Fix lint!",
+    "test": "vitest"
   },
   "dependencies": {
     "@inquirer/prompts": "^3.3.2",
@@ -54,6 +55,7 @@
     "tsc": "^2.0.4",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
+    "vitest": "^3.2.1",
     "wrangler": "^3.0.0"
   }
 }

--- a/src/cli/__tests__/validators.test.ts
+++ b/src/cli/__tests__/validators.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { validDomainName } from '../validators'
+
+describe('validDomainName', () => {
+  it('accepts valid domains', () => {
+    const validSamples = ['example.com', 'foo.example.co.uk', 'my-site.io']
+    for (const sample of validSamples) {
+      expect(validDomainName(sample)).toBe(true)
+    }
+  })
+
+  it('rejects invalid domains', () => {
+    const invalidSamples = ['', 'foo..com', '-start.com', 'exa_mple.com', '*.example.com']
+    for (const sample of invalidSamples) {
+      expect(validDomainName(sample)).toBeFalsy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest test framework
- add test script
- test validators for domain names

## Testing
- `pnpm test -- -t validDomainName --run`


------
https://chatgpt.com/codex/tasks/task_e_683f88cefca08322b32e89c03486cafb